### PR TITLE
Bugfix: do not bypass backoffs when RPC fails

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -105,16 +105,19 @@ class BlindPeerClient extends ReadyResource {
       this.emit('stream', rpc.stream)
 
       await socket.opened
+      try {
+        await rpc.fullyOpened()
+      } catch (e) {
+        safetyCatch(e)
+      }
 
-      if (!socket.destroying && !socket.destroyed) break
+      if (!socket.destroying && !socket.destroyed && rpc.opened && !rpc.closed) break
       if (this.closing || this.suspended || this.dht.destroyed) break
 
       await this._backoff.run()
     }
 
     if (this.closing || this.suspended || this.dht.destroyed) return
-
-    this.rpc.on('close', () => this._backgroundConnect())
 
     this.connected = true
     this._signal.notify()


### PR DESCRIPTION
Previous behaviour is that it bypasses the backoff logic when the RPC errors, meaning it ends up spamming the blind peer with connection attempts and requests/

The fix puts the 'open RPC' logic explicitly in the connection step, for simplicity.

Tests pass against blind-peer#main