### PR TITLE
Add connection timeouts

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -19,6 +19,7 @@ class BlindPeerClient extends ReadyResource {
     this.relayThrough = opts.relayThrough || null
     this.connected = false
     this.backoffValues = opts.backoffValues || [1000, 1000, 1000, 2000, 2000, 3000, 3000, 5000, 5000, 15000, 30000, 60000]
+    this.timeout = opts.timeout || 10000
 
     this._connecting = null
     this._signal = new Signal()
@@ -167,19 +168,23 @@ class BlindPeerClient extends ReadyResource {
 
     let error = null
 
+    const maxTime = Date.now() + this.timeout
     for (let i = 0; i < this.backoffValues.length * 2; i++) {
-      while (!this.closing && !this.connected) {
+      while (!this.closing && !this.connected && Date.now() < maxTime) {
         this._backgroundConnect()
-        await this._signal.wait()
+        const timeout = maxTime - Date.now()
+        if (timeout > 0) await this._signal.wait(timeout)
       }
 
       if (this.closing) throw new Error('Closing')
+      const timeout = maxTime - Date.now()
+      if (timeout <= 0) throw new Error('timeout')
 
       try {
         return await this.rpc.request(
           'add-core',
           req,
-          AddCoreEncoding
+          { ...AddCoreEncoding, timeout }
         )
       } catch (err) {
         error = err


### PR DESCRIPTION
The behaviour of this PR is better than the previous, because previously it just hung forever if a blind peer was unavailable, whereas now it times out and gives up.
However, since we swallow all errors in index.js, the user never knows the request didn't go through, which is also not ideal.