### PR TITLE
Use `hyperdht-address` to decode keys for passing `nodes` support

### DIFF
--- a/index.js
+++ b/index.js
@@ -601,7 +601,9 @@ function getClosestMirrorList(key, list, n) {
 }
 
 function decodeKey([keys, keyToEncodedKey], encodedKey) {
-  const { key } = HyperDHTAddress.decode(b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey))
+  const { key } = HyperDHTAddress.decode(
+    b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
+  )
   keys.push(key)
   keyToEncodedKey.set(key, encodedKey)
   return [keys, keyToEncodedKey]

--- a/index.js
+++ b/index.js
@@ -32,7 +32,13 @@ class BlindPeering {
     this.suspended = suspended
     this.closed = false
     this.wakeup = wakeup
+
+    // TODO: on a next major, get rid of all the work arounds
+    // for making it support both hyperdht-encoded addresses
+    // and straight keys (by always using hyperdht-encoded ones)
+    this.keyToEncodedKey = null // set next line
     this.setKeys(keys)
+
     this.gcWait = gcWait
     this.pick = pick
     this.relayThrough = relayThrough
@@ -601,6 +607,8 @@ function getClosestMirrorList(key, list, n) {
 }
 
 function decodeKey(keyToEncodedKey, encodedKey) {
+  encodedKey = b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
+
   const { key } = HyperDHTAddress.decode(
     b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
   )

--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ class BlindPeering {
     this.suspended = suspended
     this.closed = false
     this.wakeup = wakeup
-    this.keys = keys
+    const [decodedKeys, keyToEncodedKey] = keys.reduce(decodeKey, [[], new Map()])
+    this.keys = decodedKeys
+    this.keyToEncodedKey = keyToEncodedKey
     this.gcWait = gcWait
     this.pick = pick
     this.relayThrough = relayThrough
@@ -63,7 +65,9 @@ class BlindPeering {
   }
 
   setKeys(keys) {
-    this.keys = keys
+    const [decodedKeys, keyToEncodedKey] = keys.reduce(decodeKey, [[], new Map()])
+    this.keys = decodedKeys
+    this.keyToEncodedKey = keyToEncodedKey
     // TODO: rebalance
   }
 
@@ -128,7 +132,7 @@ class BlindPeering {
     const all = []
 
     for (const key of getClosestMirrorList(target, keys, pick)) {
-      const peer = this._getBlindPeer(key)
+      const peer = this._getBlindPeer(this.keyToEncodedKey.get(key) || key)
       peer.addAutobase(base, { referrer, priority, announce })
       all.push(peer)
     }
@@ -185,7 +189,7 @@ class BlindPeering {
     const all = []
 
     for (const key of getClosestMirrorList(target, keys, pick)) {
-      const peer = this._getBlindPeer(key)
+      const peer = this._getBlindPeer(this.keyToEncodedKey.get(key) || key)
       peer.addCore(core, { referrer, priority, announce })
       all.push(peer)
     }
@@ -584,7 +588,7 @@ function getClosestMirrorList(key, list, n) {
   for (let i = 0; i < n; i++) {
     let current = null
     for (let j = i; j < list.length; j++) {
-      const next = xorDistance(decodeKey(list[j]).key, key)
+      const next = xorDistance(list[j], key)
       if (current && xorDistance.gt(next, current)) continue
       const tmp = list[i]
       list[i] = list[j]
@@ -596,6 +600,9 @@ function getClosestMirrorList(key, list, n) {
   return list.slice(0, n)
 }
 
-function decodeKey(encodedKey) {
-  return HyperDHTAddress.decode(b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey))
+function decodeKey([keys, keyToEncodedKey], encodedKey) {
+  const { key } = HyperDHTAddress.decode(b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey))
+  keys.push(key)
+  keyToEncodedKey.set(key, encodedKey)
+  return [keys, keyToEncodedKey]
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const BlindPeerMuxer = require('blind-peer-muxer')
 const xorDistance = require('xor-distance')
 const b4a = require('b4a')
 const ID = require('hypercore-id-encoding')
+const HyperDHTAddress = require('hyperdht-address')
 const safetyCatch = require('safety-catch')
 const Backoff = require('./lib/backoff.js')
 
@@ -31,7 +32,7 @@ class BlindPeering {
     this.suspended = suspended
     this.closed = false
     this.wakeup = wakeup
-    this.keys = keys.map(ID.decode)
+    this.keys = keys
     this.gcWait = gcWait
     this.pick = pick
     this.relayThrough = relayThrough
@@ -62,7 +63,7 @@ class BlindPeering {
   }
 
   setKeys(keys) {
-    this.keys = keys.map(ID.decode)
+    this.keys = keys
     // TODO: rebalance
   }
 
@@ -583,7 +584,7 @@ function getClosestMirrorList(key, list, n) {
   for (let i = 0; i < n; i++) {
     let current = null
     for (let j = i; j < list.length; j++) {
-      const next = xorDistance(list[j], key)
+      const next = xorDistance(decodeKey(list[j]).key, key)
       if (current && xorDistance.gt(next, current)) continue
       const tmp = list[i]
       list[i] = list[j]
@@ -593,4 +594,8 @@ function getClosestMirrorList(key, list, n) {
   }
 
   return list.slice(0, n)
+}
+
+function decodeKey(encodedKey) {
+  return HyperDHTAddress.decode(b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey))
 }

--- a/index.js
+++ b/index.js
@@ -32,9 +32,7 @@ class BlindPeering {
     this.suspended = suspended
     this.closed = false
     this.wakeup = wakeup
-    const [decodedKeys, keyToEncodedKey] = keys.reduce(decodeKey, [[], new Map()])
-    this.keys = decodedKeys
-    this.keyToEncodedKey = keyToEncodedKey
+    this.keyToEncodedKey = getKeysMap(keys)
     this.gcWait = gcWait
     this.pick = pick
     this.relayThrough = relayThrough
@@ -64,10 +62,12 @@ class BlindPeering {
     }
   }
 
+  get keys() {
+    return this.keyToEncodedKey.keys()
+  }
+
   setKeys(keys) {
-    const [decodedKeys, keyToEncodedKey] = keys.reduce(decodeKey, [[], new Map()])
-    this.keys = decodedKeys
-    this.keyToEncodedKey = keyToEncodedKey
+    this.keyToEncodedKey = getKeysMap(keys)
     // TODO: rebalance
   }
 
@@ -600,11 +600,14 @@ function getClosestMirrorList(key, list, n) {
   return list.slice(0, n)
 }
 
-function decodeKey([keys, keyToEncodedKey], encodedKey) {
+function decodeKey(keyToEncodedKey, encodedKey) {
   const { key } = HyperDHTAddress.decode(
     b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
   )
-  keys.push(key)
   keyToEncodedKey.set(key, encodedKey)
-  return [keys, keyToEncodedKey]
+  return keyToEncodedKey
+}
+
+function getKeysMap(encodedKeys) {
+  return encodedKeys.reduce(decodeKey, new Map())
 }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class BlindPeering {
     this.suspended = suspended
     this.closed = false
     this.wakeup = wakeup
-    this.keyToEncodedKey = getKeysMap(keys)
+    this.setKeys(keys)
     this.gcWait = gcWait
     this.pick = pick
     this.relayThrough = relayThrough

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ class BlindPeering {
   }
 
   get keys() {
-    return this.keyToEncodedKey.keys()
+    return Array.from(this.keyToEncodedKey.keys())
   }
 
   setKeys(keys) {

--- a/index.js
+++ b/index.js
@@ -607,11 +607,10 @@ function getClosestMirrorList(key, list, n) {
 }
 
 function decodeKey(keyToEncodedKey, encodedKey) {
+  // Ensure its a buffer
   encodedKey = b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
 
-  const { key } = HyperDHTAddress.decode(
-    b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
-  )
+  const { key } = HyperDHTAddress.decode(encodedKey)
   keyToEncodedKey.set(key, encodedKey)
   return keyToEncodedKey
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "b4a": "^1.6.7",
     "blind-peer-muxer": "^1.0.0",
     "hypercore-id-encoding": "^1.3.0",
+    "hyperdht-address": "^1.0.1",
     "safety-catch": "^1.0.2",
     "xor-distance": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "blind-peer-muxer": "^1.0.0",
     "hypercore-id-encoding": "^1.3.0",
     "hyperdht-address": "^1.0.1",
+    "hyperdht": "^6.30.0",
     "safety-catch": "^1.0.2",
     "xor-distance": "^2.0.0"
   },


### PR DESCRIPTION
Main caveat is that the decoding of the keys happens later as the encoded version is passed to the `BlindPeer` class. This means that encoding errors would be thrown later.