### PR TITLE
Add blind peer grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Create a new Blind Peering instance. `dht` is a HyperDHT instance and `store` is
 
 `opts` include:
 
-- `keys`: a list of blind peer keys (mirrors) to use. You should always set this, otherwise there are no mirrors to contact.
+- `blindPeers`: a list of `{ key, group }` blind peers (mirrors) to use. You should always set this, otherwise there are no mirrors to contact. `group` is optional and indicates where the blind peer is hosted, so that mirrors for the same core are picked from different groups where possible.
 - `suspended`: whether to start in suspended state (default `false`)
 - `wakeup`: a Wakeup object
+
+#### `blindPeering.setBlindPeers(blindPeers)`
+
+Replace the list of blind peers, in the same `{ key, group }` form the constructor takes, and re-add the currently mirrored cores and autobases to the new set.
 
 #### `await blindPeering.addCore(core, { target = core.key, ...opts })`
 
@@ -32,6 +36,7 @@ Add a Hypercore to a blind peer.
 - `mirrors`: how many blind peers to contact. Defaults to 1.
 - `referrer`: key of a referrer hypercore to pass to the blind peer
 - `priority`: integer indicating the priority to request. See Blind Peer for the possibilities
+- `blindPeers`: use these `{ key, group }` blind peers instead of the configured ones, for a core that should live on its own set of mirrors
 
 #### `blindPeering.addCoreBackground(core, { target = core.key, ...opts })`
 

--- a/index.js
+++ b/index.js
@@ -764,9 +764,12 @@ function getClosestMirrorList(key, list, n) {
 
   if (n > list.length) n = list.length
 
+  const usedGroups = new Set()
+
   for (let i = 0; i < n; i++) {
     let current = null
     for (let j = i; j < list.length; j++) {
+      if (usedGroups.has(list[j].group)) continue
       const next = xorDistance(list[j].key, key)
       if (current && xorDistance.gt(next, current)) continue
       const tmp = list[i]
@@ -774,6 +777,13 @@ function getClosestMirrorList(key, list, n) {
       list[j] = tmp
       current = next
     }
+    if (current === null) {
+      // Every remaining peer is from a used group, clear so we keep balancing across groups
+      usedGroups.clear()
+      i--
+      continue
+    }
+    if (list[i].group) usedGroups.add(list[i].group)
   }
 
   return list.slice(0, n)

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ class BlindPeering {
     // for making it support both hyperdht-encoded addresses
     // and straight keys (by always using hyperdht-encoded ones)
     this.blindPeerInfos = null // set below
-    this.keyToEncodedKey = null // set below
 
     if (blindPeers?.length) this.setBlindPeers(blindPeers)
     else this.setKeys(keys)
@@ -79,7 +78,7 @@ class BlindPeering {
   }
 
   get keys() {
-    return Array.from(this.keyToEncodedKey.keys())
+    return Array.from(this.blindPeerInfos.map(({ key }) => key))
   }
 
   setKeys(keys) {
@@ -87,14 +86,7 @@ class BlindPeering {
   }
 
   setBlindPeers(blindPeers) {
-    this.blindPeerInfos = []
-    this.keyToEncodedKey = new Map()
-
-    for (const blindPeer of blindPeers) {
-      const { key, encodedKey } = decodeKey(blindPeer.key)
-      this.blindPeerInfos.push({ key, group: blindPeer.group })
-      this.keyToEncodedKey.set(key, encodedKey)
-    }
+    this.blindPeerInfos = toBlindPeerInfos(blindPeers)
 
     const uniqueCores = new Map()
     const uniqueBases = new Map()
@@ -187,7 +179,7 @@ class BlindPeering {
     const all = []
 
     for (const mirror of getClosestMirrorList(target, mirrors, pick)) {
-      const peer = this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key)
+      const peer = this._getBlindPeer(mirror.encodedKey)
       peer.addAutobase(auto, { target, referrer, priority, announce, additionalViews, pick })
       all.push(peer)
     }
@@ -220,16 +212,16 @@ class BlindPeering {
   }
 
   _getMirrors(blindPeers, keys) {
-    if (blindPeers) return blindPeers
-    if (keys) return keys.map((key) => ({ key }))
+    if (blindPeers) return toBlindPeerInfos(blindPeers)
+    if (keys) return toBlindPeerInfos(keys.map((key) => ({ key })))
     return this.blindPeerInfos
   }
 
-  _getBlindPeer(key) {
-    const id = b4a.toString(key, 'hex')
+  _getBlindPeer(encodedKey) {
+    const id = b4a.toString(encodedKey, 'hex')
     let peer = this.blindPeers.get(id)
     if (peer) return peer
-    peer = new BlindPeer(this, key, { backoffResetWait: this.backoffResetWait })
+    peer = new BlindPeer(this, encodedKey, { backoffResetWait: this.backoffResetWait })
     this.blindPeers.set(id, peer)
     return peer
   }
@@ -252,7 +244,7 @@ class BlindPeering {
     const all = []
 
     for (const mirror of getClosestMirrorList(target, mirrors, pick)) {
-      const peer = this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key)
+      const peer = this._getBlindPeer(mirror.encodedKey)
       peer.addCore(core, { target, referrer, priority, announce, pick })
       all.push(peer)
     }
@@ -296,7 +288,7 @@ class BlindPeering {
     }
 
     const closestMirrors = getClosestMirrorList(target, mirrors, this.pick)
-    const peers = closestMirrors.map((mirror) => this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key))
+    const peers = closestMirrors.map((mirror) => this._getBlindPeer(mirror.encodedKey))
     const connectedPeer = peers.find((peer) => peer.connected)
     if (connectedPeer) {
       await connectedPeer.sendNotification(request)
@@ -793,4 +785,11 @@ function decodeKey(encodedKey) {
 
   const { key } = HyperDHTAddress.decode(encodedKey)
   return { key, encodedKey }
+}
+
+function toBlindPeerInfos(blindPeers) {
+  return blindPeers.map((blindPeer) => {
+    const { key, encodedKey } = decodeKey(blindPeer.key)
+    return { key, encodedKey, group: blindPeer.group }
+  })
 }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class BlindPeering {
       suspended = false,
       wakeup = null,
       keys = [],
+      blindPeers = [],
       gcWait = 2000,
       pick = 2,
       relayThrough = null,
@@ -41,8 +42,11 @@ class BlindPeering {
     // TODO: on a next major, get rid of all the work arounds
     // for making it support both hyperdht-encoded addresses
     // and straight keys (by always using hyperdht-encoded ones)
-    this.keyToEncodedKey = null // set next line
-    this.setKeys(keys)
+    this.blindPeerInfos = null // set below
+    this.keyToEncodedKey = null // set below
+
+    if (blindPeers?.length) this.setBlindPeers(blindPeers)
+    else this.setKeys(keys)
 
     this.gcWait = gcWait
     this.pick = pick
@@ -79,7 +83,18 @@ class BlindPeering {
   }
 
   setKeys(keys) {
-    this.keyToEncodedKey = getKeysMap(keys)
+    this.setBlindPeers(keys.map((key) => ({ key })))
+  }
+
+  setBlindPeers(blindPeers) {
+    this.blindPeerInfos = []
+    this.keyToEncodedKey = new Map()
+
+    for (const blindPeer of blindPeers) {
+      const { key, encodedKey } = decodeKey(blindPeer.key)
+      this.blindPeerInfos.push({ key, group: blindPeer.group })
+      this.keyToEncodedKey.set(key, encodedKey)
+    }
 
     const uniqueCores = new Map()
     const uniqueBases = new Map()
@@ -157,9 +172,12 @@ class BlindPeering {
       announce,
       additionalViews,
       pick = this.pick,
-      keys = this.keys
+      keys = null,
+      blindPeers = null
     } = {}
   ) {
+    const mirrors = this._getMirrors(blindPeers, keys)
+
     await auto.ready()
     if (auto.closing) return
 
@@ -168,8 +186,8 @@ class BlindPeering {
 
     const all = []
 
-    for (const key of getClosestMirrorList(target, keys, pick)) {
-      const peer = this._getBlindPeer(this.keyToEncodedKey.get(key) || key)
+    for (const mirror of getClosestMirrorList(target, mirrors, pick)) {
+      const peer = this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key)
       peer.addAutobase(auto, { target, referrer, priority, announce, additionalViews, pick })
       all.push(peer)
     }
@@ -201,6 +219,12 @@ class BlindPeering {
     if (this._gc.size === 0) this._stopGC()
   }
 
+  _getMirrors(blindPeers, keys) {
+    if (blindPeers) return blindPeers
+    if (keys) return keys.map((key) => ({ key }))
+    return this.blindPeerInfos
+  }
+
   _getBlindPeer(key) {
     const id = b4a.toString(key, 'hex')
     let peer = this.blindPeers.get(id)
@@ -216,8 +240,10 @@ class BlindPeering {
 
   async addCore(
     core,
-    { target, referrer, priority, announce, pick = this.pick, keys = this.keys } = {}
+    { target, referrer, priority, announce, pick = this.pick, keys = null, blindPeers = null } = {}
   ) {
+    const mirrors = this._getMirrors(blindPeers, keys)
+
     await core.ready()
     if (core.closing) return
 
@@ -225,8 +251,8 @@ class BlindPeering {
 
     const all = []
 
-    for (const key of getClosestMirrorList(target, keys, pick)) {
-      const peer = this._getBlindPeer(this.keyToEncodedKey.get(key) || key)
+    for (const mirror of getClosestMirrorList(target, mirrors, pick)) {
+      const peer = this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key)
       peer.addCore(core, { target, referrer, priority, announce, pick })
       all.push(peer)
     }
@@ -245,11 +271,14 @@ class BlindPeering {
       roomDiscoveryKey = hcCrypto.discoveryKey(roomKey),
       index = null,
       target = core.key,
-      keys = this.keys,
+      keys = null,
+      blindPeers = null,
       extra = null,
       appId = null
     } = {}
   ) {
+    const mirrors = this._getMirrors(blindPeers, keys)
+
     await core.ready()
     if (index === null) index = core.length - 1
 
@@ -266,9 +295,8 @@ class BlindPeering {
       appId
     }
 
-    const closestKeys = getClosestMirrorList(target, keys, this.pick)
-
-    const peers = closestKeys.map((key) => this._getBlindPeer(this.keyToEncodedKey.get(key) || key))
+    const closestMirrors = getClosestMirrorList(target, mirrors, this.pick)
+    const peers = closestMirrors.map((mirror) => this._getBlindPeer(this.keyToEncodedKey.get(mirror.key) || mirror.key))
     const connectedPeer = peers.find((peer) => peer.connected)
     if (connectedPeer) {
       await connectedPeer.sendNotification(request)
@@ -747,7 +775,7 @@ function getClosestMirrorList(key, list, n) {
   for (let i = 0; i < n; i++) {
     let current = null
     for (let j = i; j < list.length; j++) {
-      const next = xorDistance(list[j], key)
+      const next = xorDistance(list[j].key, key)
       if (current && xorDistance.gt(next, current)) continue
       const tmp = list[i]
       list[i] = list[j]
@@ -759,15 +787,10 @@ function getClosestMirrorList(key, list, n) {
   return list.slice(0, n)
 }
 
-function decodeKey(keyToEncodedKey, encodedKey) {
+function decodeKey(encodedKey) {
   // Ensure its a buffer
   encodedKey = b4a.isBuffer(encodedKey) ? encodedKey : ID.decode(encodedKey)
 
   const { key } = HyperDHTAddress.decode(encodedKey)
-  keyToEncodedKey.set(key, encodedKey)
-  return keyToEncodedKey
-}
-
-function getKeysMap(encodedKeys) {
-  return encodedKeys.reduce(decodeKey, new Map())
+  return { key, encodedKey }
 }


### PR DESCRIPTION
Introduces the notion of blind peer groups so that blind peers can be selected from different groups where possible. Blind peers with no groups will continue being selected as usual.

Adds a new method `setBlindPeers(blindPeers)`, where `blindPeers` is a list of `{ key, group }`, to be used instead of `setKeys`, though `setKeys` is still supported and is equivalent to setting blind peers with no groups.

Also adds a new `blindPeers` option to be used instead of `keys` to the following methods:
- `new BlindPeering` constructor
- `addCore`
- `addCoreBackground`
- `addAutobase`
- `addAutobaseBackground`
- `sendNotification`

It might be nice to drop `keys()`, `setKeys()`, and the `keys` params in a future major.

Disclaimer: AI assistance used on selection algorithm and docs