### PR TITLE
Bugfix: use encoded key if it exists in sendNotification

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,8 @@ class BlindPeering {
     }
 
     const closestKeys = getClosestMirrorList(target, keys, this.pick)
-    const peers = closestKeys.map((key) => this._getBlindPeer(key))
+
+    const peers = closestKeys.map((key) => this._getBlindPeer(this.keyToEncodedKey.get(key) || key))
     const connectedPeer = peers.find((peer) => peer.connected)
     if (connectedPeer) {
       await connectedPeer.sendNotification(request)


### PR DESCRIPTION
Similar to addAutobase etc, otherwise we can get 2 different refs to the same blind peer