### PR TITLE
BUGFIX: sending notifications does not affect gc lifecycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -682,6 +682,7 @@ class BlindPeer {
 
   async sendNotification(request) {
     this.pendingNotifications++
+    this.update()
     try {
       if (!this.connected) {
         // Don’t wait for the full retry duration. Fail fast so the caller can switch to another blind-peer

--- a/index.js
+++ b/index.js
@@ -707,6 +707,7 @@ class BlindPeer {
       this.peering.stats.notificationsTx++
     } finally {
       this.pendingNotifications--
+      this.update()
     }
   }
 


### PR DESCRIPTION
Tested in: https://github.com/holepunchto/blind-peer/pull/189

The original code correctly added `pendingNotifications` check into `hasRef()` [here](https://github.com/holepunchto/blind-peering/blob/main/index.js#L450)

Which is then used in the `update()` method to check if a peer needs to be added or removed from gc. [here](https://github.com/holepunchto/blind-peering/blob/main/index.js#L533) 

That's the only part in the code that adds or removes peers from gc.

The bug is that `sendNotification` modifies `pendingNotifications`, but does not actually call `update()` method which is what does the check.

The fix is to call `update()` every time `pendingNotifications` changes. Just how `update()` is called every time core/base enters or leaves.


I've considered modifying gc loop itself, to check `hasRef` on its own before actually gc'ing a peer. [here](https://github.com/holepunchto/blind-peering/blob/main/index.js#L190)
Then gc would never remove peers with refs.

But in that case notification would not reset the gc counter if the send happened between gc ticks. With two `update()` it always leaves gc at beginning and re-enter at the end. Which seems more correct and doesn't require changing core gc loop.

